### PR TITLE
Enforce native Python ``str`` for ``blockData`` in ``MCStructure.setBlock()``

### DIFF
--- a/mcschematic.py
+++ b/mcschematic.py
@@ -1259,7 +1259,15 @@ class MCStructure:
 
         :param position: The position to place the blockData at
         :param blockData: The blockData to place
+        :raises TypeError: if blockData is not a native Python string.
         """
+
+        # validate blockData type
+        if not isinstance(blockData, str) or type(blockData) != str:
+            raise TypeError(
+                f"blockData must be a native Python string (str), but got type {type(blockData)}. "
+                f"Value: '{str(blockData)[:100]}{'...' if len(str(blockData)) > 100 else ''}'"
+            )
 
         # We have a different treatment between block entities
         # and normal blocks.


### PR DESCRIPTION
This commit addresses an issue where schem could be generated with an incomplete block palette (making it corrupt) if non-native Python string types (e.g., ``numpy.str_``) were passed as ``blockData`` to ``MCStructure.setBlock()``.

The reason the block palette could be incomplete in this case is because ``MCStructure.getBlockPalette()`` method filters keys from ``_blockPalette`` using the check: ``type(key) == str``.